### PR TITLE
playing empty records doesn't crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 nosetests.xml
 build/
 dist/
+dalton/tests/test_recordings/google_test/
+dalton/tests/test_recordings/empty_test/

--- a/dalton/__init__.py
+++ b/dalton/__init__.py
@@ -214,7 +214,7 @@ class Player(object):
         self._caller = caller
         self._global = use_global
         self._module = __import__(mod_name)
-        self._current_step = getattr(self._module, 'StepNumber0')
+        self._current_step = getattr(self._module, 'StepNumber0', None)
         self._current_request = None
 
     def play(self):

--- a/dalton/tests/__init__.py
+++ b/dalton/tests/__init__.py
@@ -41,6 +41,15 @@ class TestRecorder(unittest.TestCase):
         assert os.path.exists(os.path.join(test_dir, '__init__.py'))
         assert os.path.exists(os.path.join(test_dir, 'step_1_request.txt'))
 
+    def testEmptySave(self):
+        h = self._makeHttp('www.google.com')
+        recorder = dalton.Recorder(caller=h)
+        with recorder.recording():
+            pass # does not do any request
+        assert len(recorder._interaction) == 0
+        test_dir = os.path.join(here, 'test_recordings', 'empty_test')
+        recorder.save(test_dir)
+
 
 class TestGlobalRecorder(unittest.TestCase):
     def _makeHttp(self, host):
@@ -96,6 +105,16 @@ class TestPlayer(unittest.TestCase):
         assert '<title>GoogleFoo</title>' in body
         assert resp.getheader('x-xss-protection') == '1; mode=block'
         assert len(resp.getheaders()) == 8
+
+    def testEmptyPlay(self):
+        h = self._makeHttp('www.google.com')
+        test_dir = os.path.join(here, 'test_recordings', 'empty_play_test')
+        player = dalton.Player(caller=h, playback_dir=test_dir)
+
+        with player.playing(): # shouldn't crash here
+            with self.assertRaises(Exception):
+                h.request('GET', '/')
+
 
 
 class TestGlobalPlayer(unittest.TestCase):

--- a/dalton/tests/test_recordings/empty_play_test/__init__.py
+++ b/dalton/tests/test_recordings/empty_play_test/__init__.py
@@ -1,0 +1,5 @@
+import os
+import dalton
+from dalton import FileWrapper
+
+here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(name='dalton',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
+      test_suite="dalton.tests",
       install_requires=[
       ],
       entry_points="""


### PR DESCRIPTION
Hi Ben,

I create a new interaction record for every unit test using this TestCase class : https://gist.github.com/1759559 .
Some of the recordings are therefore empty, which crashes dalton when I load them. This pull request fixes that.

I also added the tests to the setup() test_suites argument so that it's now possible to run the tests with :

```
python setup.py test
```

Best,
Gautier
