### PR TITLE
Prevent Problems on Double Import

### DIFF
--- a/dalton/__init__.py
+++ b/dalton/__init__.py
@@ -15,11 +15,12 @@ __all__ = ['inject', 'Recorder', 'Player', 'FileWrapper']
 
 def inject():
     """Monkey-patch httplib with Dalton"""
-    httplib.HTTPConnection._orig_request = httplib.HTTPConnection.request
-    httplib.HTTPConnection._orig_getresponse = httplib.HTTPConnection.getresponse
-    httplib.HTTPConnection.request = _request
-    httplib.HTTPConnection.getresponse = _getresponse
-    httplib.HTTPConnection._intercept = _intercept
+    if not hasattr(httplib.HTTPConnection, '_orig_request'):
+        httplib.HTTPConnection._orig_request = httplib.HTTPConnection.request
+        httplib.HTTPConnection._orig_getresponse = httplib.HTTPConnection.getresponse
+        httplib.HTTPConnection.request = _request
+        httplib.HTTPConnection.getresponse = _getresponse
+        httplib.HTTPConnection._intercept = _intercept
 
 
 class RegisteredInjections(threading.local):

--- a/dalton/tests/__init__.py
+++ b/dalton/tests/__init__.py
@@ -6,6 +6,25 @@ dalton.inject()
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+class TestInject(unittest.TestCase):
+    def _makeHttp(self, host):
+        from httplib import HTTPConnection
+        return HTTPConnection(host)
+
+    def testPlainRequest(self):
+        """Test to make sure that plain, untampered-with requests still work."""
+        h = self._makeHttp('www.google.com')
+        h.request('GET', '/')
+        resp = h.getresponse()
+        body = resp.read()
+
+    def testDoubleInject(self):
+        """Test to ensure that inject()ing twice doesn't cause trouble."""
+        dalton.inject()
+        h = self._makeHttp('www.google.com')
+        h.request('GET', '/')
+        resp = h.getresponse()
+        body = resp.read()
 
 class TestRecorder(unittest.TestCase):
     def _makeHttp(self, host):


### PR DESCRIPTION
Yes, you're not supposed to call import() twice, but having un-intercepted HTTP requests exceed the recursion limit is a poor way of indicating this.
